### PR TITLE
Adds support for reading taggings

### DIFF
--- a/tagging.go
+++ b/tagging.go
@@ -1,0 +1,27 @@
+package feedbin
+
+import (
+	"context"
+	"net/http"
+)
+
+func (r *Feedbin) GetTaggings(ctx context.Context) (*GetTaggingsResp, error) {
+	uri := "https://api.feedbin.com/v2/taggings.json"
+	resp := new(GetTaggingsResp)
+
+	_, err := r.request(ctx, http.MethodGet, uri, nil, true, &resp.Taggings)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+type Tagging struct {
+	ID     int    `json:"id"`
+	FeedID int    `json:"feed_id"`
+	Name   string `json:"name"`
+}
+
+type GetTaggingsResp struct {
+	Taggings []*Tagging `json:"taggings"`
+}


### PR DESCRIPTION
Adds support for reading the taggings of feeds

https://github.com/feedbin/feedbin-api/blob/master/content/taggings.md

Looks like

```
(*feedbin.GetTaggingsResp)(0xc000274270)({
 Taggings: ([]*feedbin.Tagging) (len=87 cap=94) {
  (*feedbin.Tagging)(0xc00046e080)({
   ID: (int) 6167208,
   FeedID: (int) 2265175,
   Name: (string) (len=11) "Individuals"
  }),
  (*feedbin.Tagging)(0xc00046e0c0)({
   ID: (int) 6167206,
   FeedID: (int) 2051250,
   Name: (string) (len=4) "Tech"
  }),
  (*feedbin.Tagging)(0xc00046e0e0)({
   ID: (int) 6167169,
   FeedID: (int) 1359263,
   Name: (string) (len=11) "Individuals"
  }),
…
```